### PR TITLE
Support the update announcement of Ssdp

### DIFF
--- a/src/main/java/io/resourcepool/jarpic/model/SsdpServiceAnnouncement.java
+++ b/src/main/java/io/resourcepool/jarpic/model/SsdpServiceAnnouncement.java
@@ -12,7 +12,7 @@ import java.util.Map;
  */
 public class SsdpServiceAnnouncement {
   public enum Status {
-    ALIVE, BYEBYE;
+    ALIVE, BYEBYE, UPDATE;
 
     /**
      * Parse NTS or ST header into a Status.
@@ -26,6 +26,9 @@ public class SsdpServiceAnnouncement {
       }
       if ("ssdp:byebye".equals(nts)) {
         return BYEBYE;
+      }
+      if ("ssdp:update".equals(nts)) {
+        return UPDATE;
       }
       return null;
     }


### PR DESCRIPTION
Services may use this if some of their data changes, i.e. the location or
other fields. Otherwise its similar to the alive/byebye announcements.

This allows users to get notified about such updates of the services
information.