### PR TITLE
Improve support for multiple network interfaces

### DIFF
--- a/src/main/java/io/resourcepool/ssdp/client/impl/SsdpClientImpl.java
+++ b/src/main/java/io/resourcepool/ssdp/client/impl/SsdpClientImpl.java
@@ -13,7 +13,11 @@ import io.resourcepool.ssdp.model.SsdpServiceAnnouncement;
 import io.resourcepool.ssdp.client.parser.ResponseParser;
 
 import java.io.IOException;
-import java.net.*;
+import java.net.DatagramPacket;
+import java.net.InetAddress;
+import java.net.MulticastSocket;
+import java.net.NetworkInterface;
+import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -216,13 +220,12 @@ public class SsdpClientImpl extends SsdpClient {
    * @throws IOException from the MulticastSocket
    */
   private void sendOnAllInterfaces(DatagramPacket packet) throws IOException {
-    if(interfaces != null && interfaces.size() > 0) {
+    if (interfaces != null && interfaces.size() > 0) {
       for (NetworkInterface iface : interfaces) {
         clientSocket.setNetworkInterface(iface);
         clientSocket.send(packet);
       }
-    }
-    else {
+    } else {
       clientSocket.send(packet);
     }
   }
@@ -235,14 +238,13 @@ public class SsdpClientImpl extends SsdpClient {
    * @throws IOException from the MulticastSocket
    */
   private void joinGroupOnAllInterfaces(InetAddress address) throws IOException {
-    if(interfaces != null && interfaces.size() > 0) {
+    if (interfaces != null && interfaces.size() > 0) {
       InetSocketAddress socketAddress = new InetSocketAddress(address, 65535); // the port number does not matter here. it is ignored
 
       for (NetworkInterface iface : interfaces) {
         this.clientSocket.joinGroup(socketAddress, iface);
       }
-    }
-    else {
+    } else {
       this.clientSocket.joinGroup(address);
     }
   }
@@ -255,14 +257,13 @@ public class SsdpClientImpl extends SsdpClient {
    * @throws IOException from the MulticastSocket
    */
   private void leaveGroupOnAllInterfaces(InetAddress address) throws IOException {
-    if(interfaces != null && interfaces.size() > 0) {
+    if (interfaces != null && interfaces.size() > 0) {
       InetSocketAddress socketAddress = new InetSocketAddress(address, 65535); // the port number does not matter here. it is ignored
 
       for (NetworkInterface iface : interfaces) {
         this.clientSocket.leaveGroup(socketAddress, iface);
       }
-    }
-    else {
+    } else {
       this.clientSocket.leaveGroup(address);
     }
   }

--- a/src/main/java/io/resourcepool/ssdp/client/impl/SsdpClientImpl.java
+++ b/src/main/java/io/resourcepool/ssdp/client/impl/SsdpClientImpl.java
@@ -13,8 +13,7 @@ import io.resourcepool.ssdp.model.SsdpServiceAnnouncement;
 import io.resourcepool.ssdp.client.parser.ResponseParser;
 
 import java.io.IOException;
-import java.net.DatagramPacket;
-import java.net.MulticastSocket;
+import java.net.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -48,6 +47,7 @@ public class SsdpClientImpl extends SsdpClient {
   private State state;
   private Map<String, SsdpService> cache = new ConcurrentHashMap<String, SsdpService>();
   private MulticastSocket clientSocket;
+  private List<NetworkInterface> interfaces;
 
   /**
    * Reset all stateful attributes.
@@ -143,10 +143,10 @@ public class SsdpClientImpl extends SsdpClient {
       }
       for (DiscoveryRequest req : requests) {
         if (req.getServiceTypes() == null || req.getServiceTypes().isEmpty()) {
-          clientSocket.send(SsdpDiscovery.getDatagram(null));
+          sendOnAllInterfaces(SsdpDiscovery.getDatagram(null));
         } else {
           for (String st : req.getServiceTypes()) {
-            clientSocket.send(SsdpDiscovery.getDatagram(st));
+            sendOnAllInterfaces(SsdpDiscovery.getDatagram(st));
           }
         }
       }
@@ -165,8 +165,8 @@ public class SsdpClientImpl extends SsdpClient {
   private void openAndBindSocket() {
     try {
       this.clientSocket = new MulticastSocket();
-      Utils.selectAppropriateInterface(clientSocket);
-      this.clientSocket.joinGroup(SsdpParams.getSsdpMulticastAddress());
+      interfaces = Utils.getMulticastInterfaces();
+      joinGroupOnAllInterfaces(SsdpParams.getSsdpMulticastAddress());
     } catch (IOException e) {
       callback.onFailed(e);
     }
@@ -208,6 +208,65 @@ public class SsdpClientImpl extends SsdpClient {
     cache.put(ssdpService.getSerialNumber(), ssdpService);
   }
 
+  /**
+   * Send the datagram packet on all interfaces.
+   *
+   * Falls back to the default send() if the interfaces list is not populated
+   * @param packet the datagram to send
+   * @throws IOException from the MulticastSocket
+   */
+  private void sendOnAllInterfaces(DatagramPacket packet) throws IOException {
+    if(interfaces != null && interfaces.size() > 0) {
+      for (NetworkInterface iface : interfaces) {
+        clientSocket.setNetworkInterface(iface);
+        clientSocket.send(packet);
+      }
+    }
+    else {
+      clientSocket.send(packet);
+    }
+  }
+
+  /**
+   * Joins the given multicast group on all interfaces.
+   *
+   * Falls back to the default joinGroup() if the interfaces list is not populated
+   * @param address the multicast group address
+   * @throws IOException from the MulticastSocket
+   */
+  private void joinGroupOnAllInterfaces(InetAddress address) throws IOException {
+    if(interfaces != null && interfaces.size() > 0) {
+      InetSocketAddress socketAddress = new InetSocketAddress(address, 65535); // the port number does not matter here. it is ignored
+
+      for (NetworkInterface iface : interfaces) {
+        this.clientSocket.joinGroup(socketAddress, iface);
+      }
+    }
+    else {
+      this.clientSocket.joinGroup(address);
+    }
+  }
+
+  /**
+   * Leaves the multicast group on all interfaces.
+   *
+   * Falls back to the default leaveGroup() if the interfaces list is not populated
+   * @param address the multicast group address
+   * @throws IOException from the MulticastSocket
+   */
+  private void leaveGroupOnAllInterfaces(InetAddress address) throws IOException {
+    if(interfaces != null && interfaces.size() > 0) {
+      InetSocketAddress socketAddress = new InetSocketAddress(address, 65535); // the port number does not matter here. it is ignored
+
+      for (NetworkInterface iface : interfaces) {
+        this.clientSocket.leaveGroup(socketAddress, iface);
+      }
+    }
+    else {
+      this.clientSocket.leaveGroup(address);
+    }
+  }
+
   @Override
   public void stopDiscovery() {
     this.state = State.STOPPING;
@@ -216,12 +275,13 @@ public class SsdpClientImpl extends SsdpClient {
     this.callback = null;
     this.requests = null;
     try {
-      this.clientSocket.leaveGroup(SsdpParams.getSsdpMulticastAddress());
+      leaveGroupOnAllInterfaces(SsdpParams.getSsdpMulticastAddress());
     } catch (IOException e) {
       // Fail silently
     } finally {
       this.clientSocket.close();
     }
+    this.interfaces = null;
     this.state = State.IDLE;
   }
 }

--- a/src/main/java/io/resourcepool/ssdp/client/util/Utils.java
+++ b/src/main/java/io/resourcepool/ssdp/client/util/Utils.java
@@ -4,7 +4,9 @@ import java.net.InetAddress;
 import java.net.MulticastSocket;
 import java.net.NetworkInterface;
 import java.net.SocketException;
+import java.util.ArrayList;
 import java.util.Enumeration;
+import java.util.List;
 
 /**
  * Utils used by the SsdpClient.
@@ -14,13 +16,12 @@ import java.util.Enumeration;
 public abstract class Utils {
 
   /**
-   * Selects the appropriate interface to use Multicast.
-   * This prevents computers with multiple interfaces to select the wrong one by default.
+   * Creates a list of viable network interfaces for Multicast.
    *
-   * @param socket the socket on which we want to bind the specific interface.
    * @throws SocketException if something bad happens
    */
-  public static void selectAppropriateInterface(MulticastSocket socket) throws SocketException {
+  public static List<NetworkInterface> getMulticastInterfaces() throws SocketException {
+    List<NetworkInterface> viableInterfaces = new ArrayList<NetworkInterface>();
     Enumeration e = NetworkInterface.getNetworkInterfaces();
     while (e.hasMoreElements()) {
       NetworkInterface n = (NetworkInterface) e.nextElement();
@@ -29,9 +30,10 @@ public abstract class Utils {
         InetAddress i = (InetAddress) ee.nextElement();
         if (i.isSiteLocalAddress() && !i.isAnyLocalAddress() && !i.isLinkLocalAddress()
             && !i.isLoopbackAddress() && !i.isMulticastAddress()) {
-          socket.setNetworkInterface(NetworkInterface.getByName(n.getName()));
+          viableInterfaces.add(NetworkInterface.getByName(n.getName()));
         }
       }
     }
+    return viableInterfaces;
   }
 }

--- a/src/main/java/io/resourcepool/ssdp/client/util/Utils.java
+++ b/src/main/java/io/resourcepool/ssdp/client/util/Utils.java
@@ -1,7 +1,6 @@
 package io.resourcepool.ssdp.client.util;
 
 import java.net.InetAddress;
-import java.net.MulticastSocket;
 import java.net.NetworkInterface;
 import java.net.SocketException;
 import java.util.ArrayList;
@@ -19,6 +18,7 @@ public abstract class Utils {
    * Creates a list of viable network interfaces for Multicast.
    *
    * @throws SocketException if something bad happens
+   * @return list of interfaces
    */
   public static List<NetworkInterface> getMulticastInterfaces() throws SocketException {
     List<NetworkInterface> viableInterfaces = new ArrayList<NetworkInterface>();


### PR DESCRIPTION
The current implementation will select only one interface and use it to send & receive packets.

(On my system `Utils.selectAppropriateInterface()` called `socket.setNetworkInterface()` four times for 2 Ethernet interfaces and 2 VMware interfaces - in the end the requests were only sent to the last interface)

Changes in this pull request:
* A list of multicast interfaces is created.
* When sending a discovery request it is explicitly sent to each interface.
* We explicitly join/leave the multicast group on each interface.