### PR TITLE
Fix bug with the default options: No newline was sent after HTTP Headers

### DIFF
--- a/src/main/java/io/resourcepool/ssdp/client/request/SsdpDiscovery.java
+++ b/src/main/java/io/resourcepool/ssdp/client/request/SsdpDiscovery.java
@@ -27,7 +27,9 @@ public abstract class SsdpDiscovery {
     sb.append("MAN: \"ssdp:discover\"\r\n");
     sb.append("MX: " + options.getMaxWaitTimeSeconds() + "\r\n");
     sb.append("USER-AGENT: " + options.getUserAgent() + "\r\n");
-    sb.append((serviceType == null || serviceType.trim().isEmpty()) ? "ST: ssdp:all\r\n" : "ST: " + serviceType + "\r\n\r\n");
+    sb.append((serviceType == null || serviceType.trim().isEmpty()) ? "ST: ssdp:all\r\n" : "ST: " + serviceType + "\r\n");
+    sb.append("\r\n");
+
     byte[] content = sb.toString().getBytes(UTF_8);
     return new DatagramPacket(content, content.length, SsdpParams.getSsdpMulticastAddress(), SsdpParams.getSsdpMulticastPort());
   }

--- a/src/main/java/io/resourcepool/ssdp/model/DiscoveryOptions.java
+++ b/src/main/java/io/resourcepool/ssdp/model/DiscoveryOptions.java
@@ -76,7 +76,7 @@ public class DiscoveryOptions {
      * @return the current builder
      */
     public Builder userAgent(String userAgent) {
-      if (userAgent != null && !userAgent.trim().isEmpty()) {
+      if (userAgent == null || userAgent.trim().isEmpty()) {
         throw new IllegalArgumentException("User-agent cannot be empty");
       }
       this.userAgent = userAgent;


### PR DESCRIPTION
If the user does not specify a ServiceType when building options, then the packet that is sent will not have a newline after the headers. This causes many well-behaved, spec-checking UPnP servers (including the widespread https://github.com/plutinosoft/Platinum) to ignore the packet and not treat it as a valid search request. Adding a newline after all the headers fixes this.

Also, I believe that your empty check logic on setting a customer user-agent was intended to prevent the user from setting an empty string as user agent or passing in a null user agent. Right now, the user can pass in null or empty user agents, resulting in strangely formed M-SEARCH packets.
