### PR TITLE
Feature: Allow user to optionally send SEARCH packets with no user-agent header

### DIFF
--- a/src/main/java/io/resourcepool/ssdp/client/request/SsdpDiscovery.java
+++ b/src/main/java/io/resourcepool/ssdp/client/request/SsdpDiscovery.java
@@ -26,7 +26,9 @@ public abstract class SsdpDiscovery {
     sb.append("HOST: " + SsdpParams.getSsdpMulticastAddress().getHostAddress() + ":" + SsdpParams.getSsdpMulticastPort() + "\r\n");
     sb.append("MAN: \"ssdp:discover\"\r\n");
     sb.append("MX: " + options.getMaxWaitTimeSeconds() + "\r\n");
-    sb.append("USER-AGENT: " + options.getUserAgent() + "\r\n");
+    if (options.getUserAgent() != null) {
+      sb.append("USER-AGENT: " + options.getUserAgent() + "\r\n");
+    }
     sb.append((serviceType == null || serviceType.trim().isEmpty()) ? "ST: ssdp:all\r\n" : "ST: " + serviceType + "\r\n\r\n");
     byte[] content = sb.toString().getBytes(UTF_8);
     return new DatagramPacket(content, content.length, SsdpParams.getSsdpMulticastAddress(), SsdpParams.getSsdpMulticastPort());

--- a/src/main/java/io/resourcepool/ssdp/model/DiscoveryOptions.java
+++ b/src/main/java/io/resourcepool/ssdp/model/DiscoveryOptions.java
@@ -72,13 +72,11 @@ public class DiscoveryOptions {
     /**
      * User agent header used in the request.
      * Defaults to "Resourcepool SSDP Client"
+     * If set to null, user agent header will not be added
      * @param userAgent the user agent
      * @return the current builder
      */
     public Builder userAgent(String userAgent) {
-      if (userAgent != null && !userAgent.trim().isEmpty()) {
-        throw new IllegalArgumentException("User-agent cannot be empty");
-      }
       this.userAgent = userAgent;
       return this;
     }


### PR DESCRIPTION
I'm making a separate PR than my bugfix https://github.com/resourcepool/ssdp-client/pull/17 to allow you to merge the bugfix quickly, and then choose if you want this new feature or not.

Allow making the user to remove the user-agent header from the request by setting a null user-agent when building the DiscoveryOptions. This can help with some old, fragile UPnP server implementations who cannot handle user-agent headers on M-SEARCH packets.

Alternatively, if you prefer, a method could be added to the DiscoveryOptions builder that removes the user agent, like .removeUserAgent(). 