### PR TITLE
Fix java.net.SocketException: setsockopt failed: EADDRINUSE (Address already in use) on Android emulators

### DIFF
--- a/src/main/java/io/resourcepool/ssdp/client/impl/SsdpClientImpl.java
+++ b/src/main/java/io/resourcepool/ssdp/client/impl/SsdpClientImpl.java
@@ -257,10 +257,16 @@ public class SsdpClientImpl extends SsdpClient {
   private void joinGroupOnAllInterfaces(InetAddress address) throws IOException {
     if (interfaces != null && interfaces.size() > 0) {
       InetSocketAddress socketAddress = new InetSocketAddress(address, 65535); // the port number does not matter here. it is ignored
-
+      List<NetworkInterface> newInterfaces = new ArrayList<>();
       for (NetworkInterface iface : interfaces) {
-        this.clientSocket.joinGroup(socketAddress, iface);
+        try {
+          this.clientSocket.joinGroup(socketAddress, iface);
+          newInterfaces.add(iface);
+        } catch (IOException e) {
+          System.err.println("Ignoring multicast interface " + iface);
+        }
       }
+      interfaces = newInterfaces;
     } else {
       this.clientSocket.joinGroup(address);
     }


### PR DESCRIPTION
Hi! 👋🏻 

And thanks for the lib 🙂 

When using the library for an Android project, I was getting the same error as #20. After a bit of debugging, it looks like on Android (at least on the emulators) `NetworkInterface.getNetworkInterfaces()` returns the same interface multiple times, resulting in an `EADDRINUSE` error.

Instead of just throwing the Exception and giving up on joining altogether, I think it makes more sense to just exclude the interfaces that fail, and keep going with those that worked. This fixed my problem.