### PR TITLE
Prevent NPE in handlePresenceAnnouncement (#35)

### DIFF
--- a/src/main/java/io/resourcepool/ssdp/client/impl/SsdpClientImpl.java
+++ b/src/main/java/io/resourcepool/ssdp/client/impl/SsdpClientImpl.java
@@ -224,7 +224,9 @@ public class SsdpClientImpl extends SsdpClient {
     if (cache.containsKey(ssdpServiceAnnouncement.getSerialNumber())) {
       callback.onServiceAnnouncement(ssdpServiceAnnouncement);
     } else if (options.getLookupAllIncomingAnnouncements()) {
-      requests.add(DiscoveryRequest.builder().serviceType(ssdpServiceAnnouncement.getServiceType()).build());
+      if (requests != null) {
+        requests.add(DiscoveryRequest.builder().serviceType(ssdpServiceAnnouncement.getServiceType()).build());
+      }
     }
   }
 


### PR DESCRIPTION
If `SsdpClientImpl.handlePresenceAnnouncement` is called before `reset`, simply ignore the announcement to prevent a NPE from happening