### PR TITLE
fix: #37

### DIFF
--- a/src/main/java/io/resourcepool/ssdp/client/impl/SsdpClientImpl.java
+++ b/src/main/java/io/resourcepool/ssdp/client/impl/SsdpClientImpl.java
@@ -219,7 +219,7 @@ public class SsdpClientImpl extends SsdpClient {
     private void handlePresenceAnnouncement(SsdpResponse response, SsdpClientOptions options) {
         SsdpServiceAnnouncement ssdpServiceAnnouncement = response.toServiceAnnouncement();
         if (ssdpServiceAnnouncement.getSerialNumber() == null) {
-            callback.onFailed(new NoSerialNumberException());
+            callback.onFailed(new NoSerialNumberException(response));
             return;
         }
         if (cache.containsKey(ssdpServiceAnnouncement.getSerialNumber())) {
@@ -239,7 +239,7 @@ public class SsdpClientImpl extends SsdpClient {
     private void handleDiscoveryResponse(SsdpResponse response, SsdpClientOptions options) {
         SsdpService ssdpService = response.toService();
         if (ssdpService.getSerialNumber() == null) {
-            callback.onFailed(new NoSerialNumberException());
+            callback.onFailed(new NoSerialNumberException(response));
             return;
         }
         // If our program disabled cache, onServiceDiscovered will always be triggered

--- a/src/main/java/io/resourcepool/ssdp/exception/NoSerialNumberException.java
+++ b/src/main/java/io/resourcepool/ssdp/exception/NoSerialNumberException.java
@@ -19,9 +19,17 @@ public class NoSerialNumberException extends RuntimeException {
 
     @Override
     public String toString() {
-        return "NoSerialNumberException{" +
-                "response=" + response +
-                '}';
+        try{
+            return "NoSerialNumberException{" +
+                    "response=" + response +
+                    '}';
+        } catch (NullPointerException e) {
+            System.err.println("NullPointerException occurred: " + e.getMessage());
+            return "NoSerialNumberException{response=null}";
+        } catch (Exception e) {
+            System.err.println("An unexpected exception occurred: " + e.getMessage());
+            return "NoSerialNumberException{unexpected error}";
+        }
     }
 
 }

--- a/src/main/java/io/resourcepool/ssdp/exception/NoSerialNumberException.java
+++ b/src/main/java/io/resourcepool/ssdp/exception/NoSerialNumberException.java
@@ -1,9 +1,27 @@
 package io.resourcepool.ssdp.exception;
 
+import io.resourcepool.ssdp.client.response.SsdpResponse;
+
 /**
  * TODO class details.
  *
  * @author Loïc Ortola on 11/11/2017
  */
 public class NoSerialNumberException extends RuntimeException {
+
+    private SsdpResponse response;
+    public NoSerialNumberException() {
+
+    }
+    public NoSerialNumberException(SsdpResponse response) {
+        this.response = response;
+    }
+
+    @Override
+    public String toString() {
+        return "NoSerialNumberException{" +
+                "response=" + response +
+                '}';
+    }
+
 }


### PR DESCRIPTION
Passing the response as a parameter of the NoSerialNumberException to help users with debugging.